### PR TITLE
modified contact us to save input data

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                     <img src="./images/illustrations/Get in touch.png" alt="Get In Touch">
                 </div>
                 <div>
-                    <form>
+                    <form id="messageForm">
                         <!-- <label for="name">Name:</label> -->
                         <input type="text" id="name" name="name" placeholder="Name" required>
         
@@ -99,7 +99,7 @@
                         <!-- <label for="message">Message:</label> -->
                         <textarea id="message" name="message" rows="8" placeholder="Message" required></textarea>
         
-                        <button type="submit">Submit</button>
+                        <button id="submit" type="submit">Submit</button>
                     </form>
                 </div>
             </div>
@@ -142,13 +142,7 @@
             Copyright &#169 opencodeera.pages.dev | All Rights Reserved
         </div>
     </footer>
-    <!-- Setup for text animation! -->
-    <script>
-        var typed = new Typed('#element', {
-            strings: ['Projects', 'Community', 'Innovation', 'Contribution'],
-            typeSpeed: 50,
-        });
-    </script>
+    <script src="./javascript/index.js"></script>
 </body>
 
 </html>

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,0 +1,30 @@
+var typed = new Typed('#element', {
+  strings: ['Projects', 'Community', 'Innovation', 'Contribution'],
+  typeSpeed: 50,
+});
+
+let contact = JSON.parse(localStorage.getItem('contact')) || {
+  name : '',
+  email: '',
+  message: ''
+};
+
+document.getElementById('name').value = contact.name;
+document.getElementById('email').value = contact.email;
+document.getElementById('message').value = contact.message;
+
+function handleFormSubmit(event) {
+  
+  event.preventDefault(); // prevents reloading of website.
+  
+  contact.name = document.getElementById('name').value;
+  contact.email = document.getElementById('email').value;
+  contact.message = document.getElementById('message').value;
+
+  localStorage.setItem('contact', JSON.stringify(contact));
+
+}
+
+const formElement = document.getElementById('messageForm');
+
+formElement.addEventListener('submit', handleFormSubmit);


### PR DESCRIPTION
This PR serves issue #24 

I have modified contact us page. So that whenever user **completely** fills out the form and clicks **Submit**. Instead of facing betrayal by the website by completely wiping out his code. The input remains there.
