### PR TITLE
fixed "projects" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
             <a class="about" href="#about">About</a>
           </li>
           <li>
-            <a class="services" target="_blank" href="https://github.com/orgs/OpenCodeEra/repositories">Projects</a>
+            <a class="services" href="javascript:void(0);" onclick="ScrollToProject()">Projects</a>
           </li>
           <li>
             <a href="team_list.html"> Team </a>

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -5,6 +5,16 @@ var typed = new Typed("#element", {
 
 const elements = document.getElementsByClassName("blur");
 
+function ScrollToProject(){
+  const projects = document.querySelector("#projects")
+  const position = projects.offsetTop - document.querySelector("nav").clientHeight;
+
+  window.scrollTo({
+    top: position - 40, // To adjust the position with <hr> tag
+    behavior: "smooth"
+  })
+}
+
 function toggle(x) {
   if (x) {
     for (let i = 0; i < elements.length; i++) {


### PR DESCRIPTION
Fixes #78 

Behavior before changes:
Clicking on the "projects" link on the navbar would take the user to github repositories.

Behavior after changes:
Clicking on the "projects" link takes the user to the projects section in the same webpage