### PR TITLE
fix: instagram and twitter logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,12 +287,12 @@
           <a href="https://github.com/OpenCodeEra" target="_blank">
             <i class="fa-brands fa-github"> </i>
           </a>
-          <a href="#">
+          <!-- <a href="#">
             <i class="fa-brands fa-x-twitter"></i>
           </a>
           <a href="#">
             <i class="fa-brands fa-instagram"></i>
-          </a>
+          </a> -->
         </div>
 
         <div id="contribution-div">


### PR DESCRIPTION
This PR fixes the issue of Instagram and twitter logo.

Fixes #104 

Since I could not find the links of Instagram and Twitter I have removed the logos .
If the links are provided I can add the logos along with their links as well

![Screenshot (764)](https://github.com/OpenCodeEra/OpenCodeEra/assets/113240231/5a4e99ed-b35d-42dd-b50e-5a3c9d6e690c)




